### PR TITLE
Incude local refinement plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ set(MODULE_PYTHON_SCRIPTS
   ${LIB_NAME}/__init__.py
   ${LIB_NAME}/AffinePlugin.py
   ${LIB_NAME}/Landmarks.py
+  ${LIB_NAME}/LocalBRAINSFitPlugin.py
+  ${LIB_NAME}/LocalSimpleITKPlugin.py
   ${LIB_NAME}/RegistrationPlugin.py
   ${LIB_NAME}/RegistrationState.py
   ${LIB_NAME}/ThinPlatePlugin.py


### PR DESCRIPTION
My laptop battery died before I could get a new Slicer build up to test this.  But it looks like these files need to be listed.

SimpleITK may need to be imported from _main_ like vtk and slicer are. I can check that on Monday. This would only affect the LocalSimpleITKPlugin.py

