### PR TITLE
BUG: Fixed Slicer startup error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ set(MODULE_PYTHON_SCRIPTS
   ${LIB_NAME}/__init__.py
   ${LIB_NAME}/AffinePlugin.py
   ${LIB_NAME}/Landmarks.py
+  ${LIB_NAME}/LocalBRAINSFitPlugin.py
+  ${LIB_NAME}/LocalSimpleITKPlugin.py 
   ${LIB_NAME}/RegistrationPlugin.py
   ${LIB_NAME}/RegistrationState.py
   ${LIB_NAME}/ThinPlatePlugin.py


### PR DESCRIPTION
.py file install was missing from CMakeLists.txt

Caused this error on Slicer startup:

Number of registered modules: 146
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "F:/S4R/Slicer-build/lib/Slicer-4.4/qt-scripted-modules/LandmarkRegistration.py", line 6, in <module>
    import RegistrationLib
  File "F:/S4R/Slicer-build/lib/Slicer-4.4/qt-scripted-modules\RegistrationLib\__init__.py", line 8, in <module>
    from LocalBRAINSFitPlugin import *
ImportError: No module named LocalBRAINSFitPlugin
setPythonSource - Failed to execute file "F:/S4R/Slicer-build/lib/Slicer-4.4/qt-scripted-modules/LandmarkRegistration.py" !
Fail to instantiate module "LandmarkRegistration"
Number of instantiated modules: 145
Number of loaded modules: 145