### PR TITLE
Fix generic test checking for cropVolume availability

### DIFF
--- a/LandmarkRegistration.py
+++ b/LandmarkRegistration.py
@@ -695,7 +695,9 @@ class LandmarkRegistrationLogic:
   def __init__(self):
     self.linearMode = 'Rigid'
     self.hiddenFiducialVolumes = ()
-    self.cropLogic = slicer.modules.cropvolume.logic()
+    self.cropLogic = None
+    if hasattr(slicer.modules, 'cropvolume'):
+      self.cropLogic = slicer.modules.cropvolume.logic()
 
 
   def setFiducialListDisplay(self,fiducialList):

--- a/RegistrationLib/LocalBRAINSFitPlugin.py
+++ b/RegistrationLib/LocalBRAINSFitPlugin.py
@@ -126,6 +126,9 @@ class LocalBRAINSFitPlugin(RegistrationLib.RegistrationPlugin):
     if self.VerboseMode == "Verbose":
       timing = True
 
+    if state.logic.cropLogic is None:
+      print("Cannot refine landmarks. CropVolume module is not available.")
+
     if state.fixed == None or state.moving == None or state.fixedFiducials == None or  state.movingFiducials == None or state.currentLandmarkName == None:
       print "Cannot refine landmarks. Images or landmarks not selected."
       return


### PR DESCRIPTION
This commit fixes 'qSlicerLandmarkRegistrationModuleGenericTest' by
gracefully failing if the CropVolume module is not available.