### PR TITLE
Centralize plugin management

### DIFF
--- a/RegistrationLib/AffinePlugin.py
+++ b/RegistrationLib/AffinePlugin.py
@@ -121,14 +121,5 @@ class AffinePlugin(RegistrationLib.RegistrationPlugin):
     self.linearMode = mode
     self.onLandmarkMoved(state)
 
-
-
-# Add this plugin to the dictionary of available registrations.
-# Since this module may be discovered before the Editor itself,
-# create the list if it doesn't already exist.
-try:
-  slicer.modules.registrationPlugins
-except AttributeError:
-  slicer.modules.registrationPlugins = {}
-slicer.modules.registrationPlugins['Affine'] = AffinePlugin
-
+from RegistrationLib import registerRegistrationPlugin
+registerRegistrationPlugin(os.path.splitext(os.path.basename(__file__))[0], globals())

--- a/RegistrationLib/LocalBRAINSFitPlugin.py
+++ b/RegistrationLib/LocalBRAINSFitPlugin.py
@@ -265,14 +265,5 @@ class LocalBRAINSFitPlugin(RegistrationLib.RegistrationPlugin):
 
     slicer.mrmlScene.EndState(slicer.mrmlScene.BatchProcessState)
 
-
-
-# Add this plugin to the dictionary of available registrations.
-# Since this module may be discovered before the Editor itself,
-# create the list if it doesn't already exist.
-try:
-  slicer.modules.registrationPlugins
-except AttributeError:
-  slicer.modules.registrationPlugins = {}
-slicer.modules.registrationPlugins['LocalBRAINSFit'] = LocalBRAINSFitPlugin
-
+from RegistrationLib import registerRegistrationPlugin
+registerRegistrationPlugin(os.path.splitext(os.path.basename(__file__))[0], globals())

--- a/RegistrationLib/LocalSimpleITKPlugin.py
+++ b/RegistrationLib/LocalSimpleITKPlugin.py
@@ -279,14 +279,5 @@ class LocalSimpleITKPlugin(RegistrationLib.RegistrationPlugin):
     end = time.time()
     print 'Refined landmark ' + state.currentLandmarkName + ' in ' + str(end - start) + ' seconds'
 
-
-
-# Add this plugin to the dictionary of available registrations.
-# Since this module may be discovered before the Editor itself,
-# create the list if it doesn't already exist.
-try:
-  slicer.modules.registrationPlugins
-except AttributeError:
-  slicer.modules.registrationPlugins = {}
-slicer.modules.registrationPlugins['LocalSimpleITK'] = LocalSimpleITKPlugin
-
+from RegistrationLib import registerRegistrationPlugin
+registerRegistrationPlugin(os.path.splitext(os.path.basename(__file__))[0], globals())

--- a/RegistrationLib/ThinPlatePlugin.py
+++ b/RegistrationLib/ThinPlatePlugin.py
@@ -158,12 +158,5 @@ class ThinPlatePlugin(RegistrationLib.RegistrationPlugin):
 
     state.transform.SetAndObserveTransformToParent(self.thinPlateTransform)
 
-
-# Add this plugin to the dictionary of available registrations.
-# Since this module may be discovered before the Editor itself,
-# create the list if it doesn't already exist.
-try:
-  slicer.modules.registrationPlugins
-except AttributeError:
-  slicer.modules.registrationPlugins = {}
-slicer.modules.registrationPlugins['ThinPlate'] = ThinPlatePlugin
+from RegistrationLib import registerRegistrationPlugin
+registerRegistrationPlugin(os.path.splitext(os.path.basename(__file__))[0], globals())

--- a/RegistrationLib/__init__.py
+++ b/RegistrationLib/__init__.py
@@ -3,7 +3,11 @@ from Visualization import *
 from Landmarks import *
 from RegistrationState import *
 from RegistrationPlugin import *
-from AffinePlugin import *
-from ThinPlatePlugin import *
-from LocalBRAINSFitPlugin import *
-from LocalSimpleITKPlugin import *
+
+for plugin in [
+  'Affine',
+  'ThinPlate',
+  'LocalBRAINSFit',
+  'LocalSimpleITK'
+  ]:
+  registerRegistrationPlugin('RegistrationLib.%sPlugin' % plugin)


### PR DESCRIPTION
This commit introduces the function 'registerRegistrationPlugin' providing
a simple way to register plugins. It avoid plugin maintainer to add
boiler plate code dealing with the 'slicer.modules.registrationPlugins'
dictionary and it makes the infrastructure more robust to code
re-organization.

It also display a warning when a plugin failed to be loaded. For example,
if Slicer is build without SimpleITK support, the following is displayed:

8<----8<----8<----8<----8<----8<----8<----8<----
[...]
Number of registered modules: 139
LandmarkRegistration: Failed to load 'RegistrationLib.LocalSimpleITKPlugin' plugin: No module named SimpleITK
Number of instantiated modules: 139
[...]
8<----8<----8<----8<----8<----8<----8<----8<----