### PR TITLE
Display a warning when a built-in registration plugin failed to be loaded.

### DIFF
--- a/RegistrationLib/__init__.py
+++ b/RegistrationLib/__init__.py
@@ -3,7 +3,15 @@ from Visualization import *
 from Landmarks import *
 from RegistrationState import *
 from RegistrationPlugin import *
-from AffinePlugin import *
-from ThinPlatePlugin import *
-from LocalBRAINSFitPlugin import *
-from LocalSimpleITKPlugin import *
+
+for plugin in [
+  'Affine',
+  'ThinPlate',
+  'LocalBRAINSFit',
+  'LocalSimpleITK'
+  ]:
+  try:
+    __import__('RegistrationLib.%sPlugin' % plugin)
+  except ImportError, details:
+    import logging
+    logging.warning("Registration: Failed to import '%s' plugin: %s" % (plugin, details))


### PR DESCRIPTION
For example, if Slicer is build without SimpleITK support, the following
is displayed:

8<----8<----8<----8<----8<----8<----8<----8<----
[...]
Number of registered modules: 139
Registration: Failed to import 'LocalSimpleITK' plugin: No module named SimpleITK
Number of instantiated modules: 139
[...]
8<----8<----8<----8<----8<----8<----8<----8<----