### PR TITLE
BUG: Fix Qt5 crash when selecting registration plugin

### DIFF
--- a/RegistrationLib/AffinePlugin.py
+++ b/RegistrationLib/AffinePlugin.py
@@ -61,26 +61,26 @@ class AffinePlugin(RegistrationPlugin):
     # - interface options for linear registration
     # - TODO: move registration code into separate plugins
     #
-    self.linearCollapsibleButton = ctk.ctkCollapsibleButton()
-    self.linearCollapsibleButton.text = "Linear Registration"
+    linearCollapsibleButton = ctk.ctkCollapsibleButton()
+    linearCollapsibleButton.text = "Linear Registration"
     linearFormLayout = qt.QFormLayout()
-    self.linearCollapsibleButton.setLayout(linearFormLayout)
-    self.widgets.append(self.linearCollapsibleButton)
+    linearCollapsibleButton.setLayout(linearFormLayout)
+    self.widgets.append(linearCollapsibleButton)
 
     buttonLayout = qt.QVBoxLayout()
-    self.linearModeButtons = {}
+    linearModeButtons = {}
     self.linearModes = ("Rigid", "Similarity", "Affine")
     for mode in self.linearModes:
-      self.linearModeButtons[mode] = qt.QRadioButton()
-      self.linearModeButtons[mode].text = mode
-      self.linearModeButtons[mode].setToolTip( "Run the registration in %s mode." % mode )
-      buttonLayout.addWidget(self.linearModeButtons[mode])
-      self.widgets.append(self.linearModeButtons[mode])
-      self.linearModeButtons[mode].connect('clicked()', lambda m=mode : self.onLinearTransform(m))
-    self.linearModeButtons[self.linearMode].checked = True
+      linearModeButtons[mode] = qt.QRadioButton()
+      linearModeButtons[mode].text = mode
+      linearModeButtons[mode].setToolTip( "Run the registration in %s mode." % mode )
+      buttonLayout.addWidget(linearModeButtons[mode])
+      self.widgets.append(linearModeButtons[mode])
+      linearModeButtons[mode].connect('clicked()', lambda m=mode : self.onLinearTransform(m))
+    linearModeButtons[self.linearMode].checked = True
     linearFormLayout.addRow("Registration Mode ", buttonLayout)
 
-    self.parent.layout().addWidget(self.linearCollapsibleButton)
+    self.parent.layout().addWidget(linearCollapsibleButton)
 
 
   def destroy(self):

--- a/RegistrationLib/LocalBRAINSFitPlugin.py
+++ b/RegistrationLib/LocalBRAINSFitPlugin.py
@@ -66,40 +66,40 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
     # Local Refinment Pane - initially hidden
     # - interface options for linear registration
     #
-    self.LocalBRAINSFitCollapsibleButton = ctk.ctkCollapsibleButton()
-    self.LocalBRAINSFitCollapsibleButton.text = "Local BRAINSFit"
-    LocalBRAINSFitFormLayout = qt.QFormLayout()
-    self.LocalBRAINSFitCollapsibleButton.setLayout(LocalBRAINSFitFormLayout)
-    self.widgets.append(self.LocalBRAINSFitCollapsibleButton)
+    localBRAINSFitCollapsibleButton = ctk.ctkCollapsibleButton()
+    localBRAINSFitCollapsibleButton.text = "Local BRAINSFit"
+    localBRAINSFitFormLayout = qt.QFormLayout()
+    localBRAINSFitCollapsibleButton.setLayout(localBRAINSFitFormLayout)
+    self.widgets.append(localBRAINSFitCollapsibleButton)
 
     buttonLayout = qt.QVBoxLayout()
-    self.LocalBRAINSFitModeButtons = {}
+    localBRAINSFitModeButtons = {}
     self.LocalBRAINSFitModes = ("Small", "Large")
     for mode in self.LocalBRAINSFitModes:
-      self.LocalBRAINSFitModeButtons[mode] = qt.QRadioButton()
-      self.LocalBRAINSFitModeButtons[mode].text = mode
-      self.LocalBRAINSFitModeButtons[mode].setToolTip( "Run the refinement in a %s local region." % mode.lower() )
-      buttonLayout.addWidget(self.LocalBRAINSFitModeButtons[mode])
-      self.widgets.append(self.LocalBRAINSFitModeButtons[mode])
-      self.LocalBRAINSFitModeButtons[mode].connect('clicked()', lambda m=mode : self.onLocalBRAINSFitMode(m))
-    self.LocalBRAINSFitModeButtons[self.LocalBRAINSFitMode].checked = True
-    LocalBRAINSFitFormLayout.addRow("Local BRAINSFit Mode ", buttonLayout)
+      localBRAINSFitModeButtons[mode] = qt.QRadioButton()
+      localBRAINSFitModeButtons[mode].text = mode
+      localBRAINSFitModeButtons[mode].setToolTip( "Run the refinement in a %s local region." % mode.lower() )
+      buttonLayout.addWidget(localBRAINSFitModeButtons[mode])
+      self.widgets.append(localBRAINSFitModeButtons[mode])
+      localBRAINSFitModeButtons[mode].connect('clicked()', lambda m=mode : self.onLocalBRAINSFitMode(m))
+    localBRAINSFitModeButtons[self.LocalBRAINSFitMode].checked = True
+    localBRAINSFitFormLayout.addRow("Local BRAINSFit Mode ", buttonLayout)
 
     buttonLayout = qt.QVBoxLayout()
-    self.VerboseModeButtons = {}
+    verboseModeButtons = {}
     self.VerboseModes = ("Quiet", "Verbose")
     for mode in self.VerboseModes:
-      self.VerboseModeButtons[mode] = qt.QRadioButton()
-      self.VerboseModeButtons[mode].text = mode
-      self.VerboseModeButtons[mode].setToolTip( "Run the refinement in %s mode." % mode.lower() )
-      buttonLayout.addWidget(self.VerboseModeButtons[mode])
-      self.widgets.append(self.VerboseModeButtons[mode])
-      self.VerboseModeButtons[mode].connect('clicked()', lambda m=mode : self.onVerboseMode(m))
-    self.VerboseModeButtons[self.VerboseMode].checked = True
-    LocalBRAINSFitFormLayout.addRow("Verbose Mode ", buttonLayout)
+      verboseModeButtons[mode] = qt.QRadioButton()
+      verboseModeButtons[mode].text = mode
+      verboseModeButtons[mode].setToolTip( "Run the refinement in %s mode." % mode.lower() )
+      buttonLayout.addWidget(verboseModeButtons[mode])
+      self.widgets.append(verboseModeButtons[mode])
+      verboseModeButtons[mode].connect('clicked()', lambda m=mode : self.onVerboseMode(m))
+    verboseModeButtons[self.VerboseMode].checked = True
+    localBRAINSFitFormLayout.addRow("Verbose Mode ", buttonLayout)
 
 
-    self.parent.layout().addWidget(self.LocalBRAINSFitCollapsibleButton)
+    self.parent.layout().addWidget(localBRAINSFitCollapsibleButton)
 
 
   def destroy(self):

--- a/RegistrationLib/LocalBRAINSFitPlugin.py
+++ b/RegistrationLib/LocalBRAINSFitPlugin.py
@@ -72,6 +72,8 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
     localBRAINSFitCollapsibleButton.setLayout(localBRAINSFitFormLayout)
     self.widgets.append(localBRAINSFitCollapsibleButton)
 
+    buttonGroup = qt.QButtonGroup()
+    self.widgets.append(buttonGroup)
     buttonLayout = qt.QVBoxLayout()
     localBRAINSFitModeButtons = {}
     self.LocalBRAINSFitModes = ("Small", "Large")
@@ -80,11 +82,14 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
       localBRAINSFitModeButtons[mode].text = mode
       localBRAINSFitModeButtons[mode].setToolTip( "Run the refinement in a %s local region." % mode.lower() )
       buttonLayout.addWidget(localBRAINSFitModeButtons[mode])
+      buttonGroup.addButton(localBRAINSFitModeButtons[mode])
       self.widgets.append(localBRAINSFitModeButtons[mode])
       localBRAINSFitModeButtons[mode].connect('clicked()', lambda m=mode : self.onLocalBRAINSFitMode(m))
     localBRAINSFitModeButtons[self.LocalBRAINSFitMode].checked = True
     localBRAINSFitFormLayout.addRow("Local BRAINSFit Mode ", buttonLayout)
 
+    buttonGroup = qt.QButtonGroup()
+    self.widgets.append(buttonGroup)
     buttonLayout = qt.QVBoxLayout()
     verboseModeButtons = {}
     self.VerboseModes = ("Quiet", "Verbose")
@@ -93,6 +98,7 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
       verboseModeButtons[mode].text = mode
       verboseModeButtons[mode].setToolTip( "Run the refinement in %s mode." % mode.lower() )
       buttonLayout.addWidget(verboseModeButtons[mode])
+      buttonGroup.addButton(verboseModeButtons[mode])
       self.widgets.append(verboseModeButtons[mode])
       verboseModeButtons[mode].connect('clicked()', lambda m=mode : self.onVerboseMode(m))
     verboseModeButtons[self.VerboseMode].checked = True

--- a/RegistrationLib/LocalSimpleITKPlugin.py
+++ b/RegistrationLib/LocalSimpleITKPlugin.py
@@ -78,39 +78,39 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
     # Local Refinment Pane - initially hidden
     # - interface options for linear registration
     #
-    self.LocalSimpleITKCollapsibleButton = ctk.ctkCollapsibleButton()
-    self.LocalSimpleITKCollapsibleButton.text = "Local SimpleITK"
-    LocalSimpleITKFormLayout = qt.QFormLayout()
-    self.LocalSimpleITKCollapsibleButton.setLayout(LocalSimpleITKFormLayout)
-    self.widgets.append(self.LocalSimpleITKCollapsibleButton)
+    localSimpleITKCollapsibleButton = ctk.ctkCollapsibleButton()
+    localSimpleITKCollapsibleButton.text = "Local SimpleITK"
+    localSimpleITKFormLayout = qt.QFormLayout()
+    localSimpleITKCollapsibleButton.setLayout(localSimpleITKFormLayout)
+    self.widgets.append(localSimpleITKCollapsibleButton)
 
     buttonLayout = qt.QVBoxLayout()
-    self.LocalSimpleITKModeButtons = {}
+    localSimpleITKModeButtons = {}
     self.LocalSimpleITKModes = ("Small", "Large")
     for mode in self.LocalSimpleITKModes:
-      self.LocalSimpleITKModeButtons[mode] = qt.QRadioButton()
-      self.LocalSimpleITKModeButtons[mode].text = mode
-      self.LocalSimpleITKModeButtons[mode].setToolTip( "Run the refinement in a %s local region." % mode.lower() )
-      buttonLayout.addWidget(self.LocalSimpleITKModeButtons[mode])
-      self.widgets.append(self.LocalSimpleITKModeButtons[mode])
-      self.LocalSimpleITKModeButtons[mode].connect('clicked()', lambda m=mode : self.onLocalSimpleITKMode(m))
-    self.LocalSimpleITKModeButtons[self.LocalSimpleITKMode].checked = True
-    LocalSimpleITKFormLayout.addRow("Local SimpleITK Mode ", buttonLayout)
+      localSimpleITKModeButtons[mode] = qt.QRadioButton()
+      localSimpleITKModeButtons[mode].text = mode
+      localSimpleITKModeButtons[mode].setToolTip( "Run the refinement in a %s local region." % mode.lower() )
+      buttonLayout.addWidget(localSimpleITKModeButtons[mode])
+      self.widgets.append(localSimpleITKModeButtons[mode])
+      localSimpleITKModeButtons[mode].connect('clicked()', lambda m=mode : self.onLocalSimpleITKMode(m))
+    localSimpleITKModeButtons[self.LocalSimpleITKMode].checked = True
+    localSimpleITKFormLayout.addRow("Local SimpleITK Mode ", buttonLayout)
 
     buttonLayout = qt.QVBoxLayout()
-    self.VerboseModeButtons = {}
+    verboseModeButtons = {}
     self.VerboseModes = ("Quiet", "Verbose", "Full Verbose")
     for mode in self.VerboseModes:
-      self.VerboseModeButtons[mode] = qt.QRadioButton()
-      self.VerboseModeButtons[mode].text = mode
-      self.VerboseModeButtons[mode].setToolTip( "Run the refinement in %s mode." % mode.lower() )
-      buttonLayout.addWidget(self.VerboseModeButtons[mode])
-      self.widgets.append(self.VerboseModeButtons[mode])
-      self.VerboseModeButtons[mode].connect('clicked()', lambda m=mode : self.onVerboseMode(m))
-    self.VerboseModeButtons[self.VerboseMode].checked = True
-    LocalSimpleITKFormLayout.addRow("Verbose Mode ", buttonLayout)
+      verboseModeButtons[mode] = qt.QRadioButton()
+      verboseModeButtons[mode].text = mode
+      verboseModeButtons[mode].setToolTip( "Run the refinement in %s mode." % mode.lower() )
+      buttonLayout.addWidget(verboseModeButtons[mode])
+      self.widgets.append(verboseModeButtons[mode])
+      verboseModeButtons[mode].connect('clicked()', lambda m=mode : self.onVerboseMode(m))
+    verboseModeButtons[self.VerboseMode].checked = True
+    localSimpleITKFormLayout.addRow("Verbose Mode ", buttonLayout)
 
-    self.parent.layout().addWidget(self.LocalSimpleITKCollapsibleButton)
+    self.parent.layout().addWidget(localSimpleITKCollapsibleButton)
 
 
   def destroy(self):

--- a/RegistrationLib/LocalSimpleITKPlugin.py
+++ b/RegistrationLib/LocalSimpleITKPlugin.py
@@ -84,6 +84,8 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
     localSimpleITKCollapsibleButton.setLayout(localSimpleITKFormLayout)
     self.widgets.append(localSimpleITKCollapsibleButton)
 
+    buttonGroup = qt.QButtonGroup()
+    self.widgets.append(buttonGroup)
     buttonLayout = qt.QVBoxLayout()
     localSimpleITKModeButtons = {}
     self.LocalSimpleITKModes = ("Small", "Large")
@@ -92,11 +94,14 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
       localSimpleITKModeButtons[mode].text = mode
       localSimpleITKModeButtons[mode].setToolTip( "Run the refinement in a %s local region." % mode.lower() )
       buttonLayout.addWidget(localSimpleITKModeButtons[mode])
+      buttonGroup.addButton(localSimpleITKModeButtons[mode])
       self.widgets.append(localSimpleITKModeButtons[mode])
       localSimpleITKModeButtons[mode].connect('clicked()', lambda m=mode : self.onLocalSimpleITKMode(m))
     localSimpleITKModeButtons[self.LocalSimpleITKMode].checked = True
     localSimpleITKFormLayout.addRow("Local SimpleITK Mode ", buttonLayout)
 
+    buttonGroup = qt.QButtonGroup()
+    self.widgets.append(buttonGroup)
     buttonLayout = qt.QVBoxLayout()
     verboseModeButtons = {}
     self.VerboseModes = ("Quiet", "Verbose", "Full Verbose")
@@ -105,6 +110,7 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
       verboseModeButtons[mode].text = mode
       verboseModeButtons[mode].setToolTip( "Run the refinement in %s mode." % mode.lower() )
       buttonLayout.addWidget(verboseModeButtons[mode])
+      buttonGroup.addButton(verboseModeButtons[mode])
       self.widgets.append(verboseModeButtons[mode])
       verboseModeButtons[mode].connect('clicked()', lambda m=mode : self.onVerboseMode(m))
     verboseModeButtons[self.VerboseMode].checked = True

--- a/RegistrationLib/RegistrationPlugin.py
+++ b/RegistrationLib/RegistrationPlugin.py
@@ -82,7 +82,8 @@ class RegistrationPlugin(object):
     """Call this method from your subclass to manage dynamic layout
     and widget deleting"""
     for w in self.widgets:
-      self.parent.layout().removeWidget(w)
+      if w.isWidgetType():
+        self.parent.layout().removeWidget(w)
       w.deleteLater()
       w.setParent(None)
     self.widgets = []

--- a/RegistrationLib/ThinPlatePlugin.py
+++ b/RegistrationLib/ThinPlatePlugin.py
@@ -58,23 +58,23 @@ class ThinPlatePlugin(RegistrationPlugin):
     #
     # Thin Plate Spline Registration Pane
     #
-    self.thinPlateCollapsibleButton = ctk.ctkCollapsibleButton()
-    self.thinPlateCollapsibleButton.text = "Thin Plate Spline Registration"
+    thinPlateCollapsibleButton = ctk.ctkCollapsibleButton()
+    thinPlateCollapsibleButton.text = "Thin Plate Spline Registration"
     thinPlateFormLayout = qt.QFormLayout()
-    self.thinPlateCollapsibleButton.setLayout(thinPlateFormLayout)
-    self.widgets.append(self.thinPlateCollapsibleButton)
+    thinPlateCollapsibleButton.setLayout(thinPlateFormLayout)
+    self.widgets.append(thinPlateCollapsibleButton)
 
     self.hotUpdateButton = qt.QCheckBox("Hot Update")
     thinPlateFormLayout.addWidget(self.hotUpdateButton)
     self.widgets.append(self.hotUpdateButton)
 
-    self.exportGridButton = qt.QPushButton("Export to Grid Transform")
-    self.exportGridButton.toolTip = "To save this transform or use it in other Slicer modules you can export the current Thin Plate transform to a Grid Transform."
-    thinPlateFormLayout.addWidget(self.exportGridButton)
-    self.exportGridButton.connect("clicked()",self.onExportGrid)
-    self.widgets.append(self.exportGridButton)
+    exportGridButton = qt.QPushButton("Export to Grid Transform")
+    exportGridButton.toolTip = "To save this transform or use it in other Slicer modules you can export the current Thin Plate transform to a Grid Transform."
+    thinPlateFormLayout.addWidget(exportGridButton)
+    exportGridButton.connect("clicked()",self.onExportGrid)
+    self.widgets.append(exportGridButton)
 
-    self.parent.layout().addWidget(self.thinPlateCollapsibleButton)
+    self.parent.layout().addWidget(thinPlateCollapsibleButton)
 
   def destroy(self):
     """Clean up"""
@@ -82,6 +82,7 @@ class ThinPlatePlugin(RegistrationPlugin):
 
   def onExportGrid(self):
     """Converts the current thin plate transform to a grid"""
+    self.hotUpdateButton = None
     state = self.registrationState()
 
     # since the transform is ras-to-ras, we find the extreme points


### PR DESCRIPTION
Fixes https://issues.slicer.org/view.php?id=4632

Prior to this commit, switching between registration type or local refinement
led to a crash. Commenting out the deleteLater() call in RegistrationPlugin.destroy
function was sufficient to avoid the crash. Only with Slicer r27484 built
against Qt5 (it has a newer version of PythonQt)

This commit removes the explicit widget references that are not needed or
explicitly set them to None (e.g, hotUpdateButton in ThinPlatePlugin).

It seems that invalid references to widgets were explicitly kept around
despite of being invalidated by the call to "deleteLater()" in the destroy
function.