### PR TITLE
BUG: Fix failing test_LandmarkRegistrationVTKv6Picking due to SampleDataSource constructor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME LandmarkRegistration)

--- a/LandmarkRegistration.py
+++ b/LandmarkRegistration.py
@@ -1076,10 +1076,10 @@ class LandmarkRegistrationTest(ScriptedLoadableModuleTest):
     #
     from SampleData import SampleDataSource, SampleDataLogic
 
-    dataSource = SampleDataSource('fixed', 'http://slicer.kitware.com/midas3/download/item/157188/small-mr-eye-fixed.nrrd', 'fixed.nrrd', 'fixed')
+    dataSource = SampleDataSource(sampleName='fixed', uris='http://slicer.kitware.com/midas3/download/item/157188/small-mr-eye-fixed.nrrd', fileNames='fixed.nrrd', nodeNames='fixed')
     fixed = SampleDataLogic().downloadFromSource(dataSource)[0]
 
-    dataSource = SampleDataSource('moving', 'http://slicer.kitware.com/midas3/download/item/157189/small-mr-eye-moving.nrrd', 'moving.nrrd', 'moving')
+    dataSource = SampleDataSource(sampleName='moving', uris='http://slicer.kitware.com/midas3/download/item/157189/small-mr-eye-moving.nrrd', fileNames='moving.nrrd', nodeNames='moving')
     moving = SampleDataLogic().downloadFromSource(dataSource)[0]
 
     self.delayDisplay('Two data sets loaded')


### PR DESCRIPTION
Failing in latest Slicer with error:

```python

ERROR: test_LandmarkRegistrationVTKv6Picking (LandmarkRegistration.LandmarkRegistrationTest)
Test the picking situation on VTKv6

Traceback (most recent call last):
  File "Slicer-build/lib/Slicer-4.11/qt-scripted-modules/LandmarkRegistration.py", line 1089, in test_LandmarkRegistrationVTKv6Picking
    w.volumeDialogSelectors["Fixed"].setCurrentNode(fixed)
TypeError: method requires a VTK object
```

SampleDataSource was changed in
https://github.com/Slicer/Slicer/commit/5d70815798b8f324b2a14ad6e9cfa1634edf9ba9

Co-authored-by: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>

