### PR TITLE
Python3 and failing test update

### DIFF
--- a/RegistrationLib/Landmarks.py
+++ b/RegistrationLib/Landmarks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import qt, slicer, os
 from . import pqWidget
 
@@ -58,8 +60,7 @@ class LandmarksWidget(pqWidget):
     # make a button for each current landmark
     self.labels = {}
     landmarks = self.logic.landmarksForVolumes(self.volumeNodes)
-    keys = landmarks.keys()
-    keys.sort()
+    keys = sorted(landmarks.keys())
     for landmarkName in keys:
       row = qt.QWidget()
       rowLayout = qt.QHBoxLayout()
@@ -175,7 +176,7 @@ class LandmarksWidget(pqWidget):
 
   def renameLandmark(self):
     landmarks = self.logic.landmarksForVolumes(self.volumeNodes)
-    if landmarks.has_key(self.selectedLandmark):
+    if self.selectedLandmark in landmarks:
       newName = qt.QInputDialog.getText(
           slicer.util.mainWindow(), "Rename Landmark",
           "New name for landmark '%s'?" % self.selectedLandmark)
@@ -196,7 +197,7 @@ class LandmarksWidget(pqWidget):
   def wrappedNodeAddedUpdate(self):
     try:
       self.nodeAddedUpdate()
-    except Exception, e:
+    except Exception as e:
       import traceback
       traceback.print_exc()
       qt.QMessageBox.warning(slicer.util.mainWindow(),

--- a/RegistrationLib/Landmarks.py
+++ b/RegistrationLib/Landmarks.py
@@ -107,10 +107,10 @@ class LandmarksWidget(pqWidget):
               fiducialList.PointEndInteractionEvent, lambda caller,event: self.onFiducialEndMoving(caller))
       self.observerTags.append( (fiducialList,tag) )
       tag = fiducialList.AddObserver(
-              fiducialList.MarkupAddedEvent, self.requestNodeAddedUpdate)
+              fiducialList.PointPositionDefinedEvent, self.requestNodeAddedUpdate)
       self.observerTags.append( (fiducialList,tag) )
       tag = fiducialList.AddObserver(
-              fiducialList.MarkupRemovedEvent, self.requestNodeAddedUpdate)
+              fiducialList.PointPositionUndefinedEvent, self.requestNodeAddedUpdate)
       self.observerTags.append( (fiducialList,tag) )
 
   def onFiducialMoved(self,fiducialList):

--- a/RegistrationLib/LocalBRAINSFitPlugin.py
+++ b/RegistrationLib/LocalBRAINSFitPlugin.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
 import time
 import vtk, qt, ctk, slicer
 from . import RegistrationPlugin
@@ -135,10 +138,10 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
       print("Cannot refine landmarks. CropVolume module is not available.")
 
     if state.fixed == None or state.moving == None or state.fixedFiducials == None or  state.movingFiducials == None or state.currentLandmarkName == None:
-      print "Cannot refine landmarks. Images or landmarks not selected."
+      print("Cannot refine landmarks. Images or landmarks not selected.")
       return
 
-    print ("Refining landmark " + state.currentLandmarkName) + " using " + self.name
+    print(("Refining landmark " + state.currentLandmarkName) + " using " + self.name)
 
     start = time.time()
 
@@ -210,10 +213,10 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
     croppedMovingVolume = slicer.mrmlScene.GetNodeByID( cvpn.GetOutputVolumeNodeID() )
     movingVolume.SetAndObserveDisplayNodeID(movingDisplayNode.GetID())
 
-    if timing: print 'Time to set up fixed ROI was ' + str(roiEnd - roiStart) + ' seconds'
-    if timing: print 'Time to set up moving ROI was ' + str(roi2End - roi2Start) + ' seconds'
-    if timing: print 'Time to crop fixed volume ' + str(cropEnd - cropStart) + ' seconds'
-    if timing: print 'Time to crop moving volume ' + str(crop2End - crop2Start) + ' seconds'
+    if timing: print('Time to set up fixed ROI was ' + str(roiEnd - roiStart) + ' seconds')
+    if timing: print('Time to set up moving ROI was ' + str(roi2End - roi2Start) + ' seconds')
+    if timing: print('Time to crop fixed volume ' + str(cropEnd - cropStart) + ' seconds')
+    if timing: print('Time to crop moving volume ' + str(crop2End - crop2Start) + ' seconds')
 
     #
     transform = slicer.vtkMRMLLinearTransformNode()
@@ -236,7 +239,7 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
     if timing: regStart = time.time()
     slicer.cli.run(slicer.modules.brainsfit, None, parameters, wait_for_completion=True)
     if timing: regEnd = time.time()
-    if timing: print 'Time for local registration ' + str(regEnd - regStart) + ' seconds'
+    if timing: print('Time for local registration ' + str(regEnd - regStart) + ' seconds')
 
     # apply the local transform to the landmark
     #print transform
@@ -249,7 +252,7 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
 
     movingList.SetNthFiducialPosition(movingIndex, tp[0], tp[1], tp[2])
     if timing: resultEnd = time.time()
-    if timing: print 'Time for transforming landmark was ' + str(resultEnd - resultStart) + ' seconds'
+    if timing: print('Time for transforming landmark was ' + str(resultEnd - resultStart) + ' seconds')
 
     # clean up cropped volmes, need to reset the foreground/background display before we delete it
     if timing: cleanUpStart = time.time()
@@ -263,10 +266,10 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
     transform = None
     matrix = None
     if timing: cleanUpEnd = time.time()
-    if timing: print 'Cleanup took ' + str(cleanUpEnd - cleanUpStart) + ' seconds'
+    if timing: print('Cleanup took ' + str(cleanUpEnd - cleanUpStart) + ' seconds')
 
     end = time.time()
-    print 'Refined landmark ' + state.currentLandmarkName + ' in ' + str(end - start) + ' seconds'
+    print('Refined landmark ' + state.currentLandmarkName + ' in ' + str(end - start) + ' seconds')
 
     slicer.mrmlScene.EndState(slicer.mrmlScene.BatchProcessState)
 

--- a/RegistrationLib/LocalSimpleITKPlugin.py
+++ b/RegistrationLib/LocalSimpleITKPlugin.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
 import time
 import qt, ctk, slicer
 from . import RegistrationPlugin
@@ -142,10 +145,10 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
       timing = True
 
     if state.fixed == None or state.moving == None or state.fixedFiducials == None or  state.movingFiducials == None or state.currentLandmarkName == None:
-      print "Cannot refine landmarks. Images or landmarks not selected."
+      print("Cannot refine landmarks. Images or landmarks not selected.")
       return
 
-    print ("Refining landmark " + state.currentLandmarkName) + " using " + self.name
+    print(("Refining landmark " + state.currentLandmarkName) + " using " + self.name)
 
     start = time.time()
     if timing: loadStart = start
@@ -156,7 +159,7 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
     fixedImage = sitk.ReadImage(sitkUtils.GetSlicerITKReadWriteAddress(fixedVolume.GetName()) )
     movingImage = sitk.ReadImage(sitkUtils.GetSlicerITKReadWriteAddress(movingVolume.GetName()) )
 
-    if timing: print 'Time for loading was ' + str(time.time() - loadStart) + ' seconds'
+    if timing: print('Time for loading was ' + str(time.time() - loadStart) + ' seconds')
 
     landmarks = state.logic.landmarksForVolumes(volumes)
 
@@ -195,7 +198,7 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
         import sys
         sys.stderr.write("Fixed landmark {0} is too close to the image border, cannot register!\n".format(state.currentLandmarkName))
         return
-    if self.VerboseMode == "Full Verbose":  print "Fixed ROI: ",fixedMinIndexes.tolist(), fixedROISize.tolist()
+    if self.VerboseMode == "Full Verbose":  print("Fixed ROI: ",fixedMinIndexes.tolist(), fixedROISize.tolist())
     if timing: roiEnd = time.time()
 
     # crop the fixed
@@ -220,7 +223,7 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
         import sys
         sys.stderr.write("Moving landmark {0} is too close to the image border, cannot register!\n".format(state.currentLandmarkName))
         return
-    if self.VerboseMode == "Full Verbose": print "Moving ROI: ",movingMinIndexes.tolist(), movingROISize.tolist()
+    if self.VerboseMode == "Full Verbose": print("Moving ROI: ",movingMinIndexes.tolist(), movingROISize.tolist())
     if timing: roi2End = time.time()
 
     if timing: crop2Start = time.time()
@@ -228,10 +231,10 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
     croppedMovingImage = sitk.Cast(croppedMovingImage, sitk.sitkFloat32)
     if timing: crop2End = time.time()
 
-    if timing: print 'Time to set up fixed ROI was ' + str(roiEnd - roiStart) + ' seconds'
-    if timing: print 'Time to set up moving ROI was ' + str(roi2End - roi2Start) + ' seconds'
-    if timing: print 'Time to crop fixed volume ' + str(cropEnd - cropStart) + ' seconds'
-    if timing: print 'Time to crop moving volume ' + str(crop2End - crop2Start) + ' seconds'
+    if timing: print('Time to set up fixed ROI was ' + str(roiEnd - roiStart) + ' seconds')
+    if timing: print('Time to set up moving ROI was ' + str(roi2End - roi2Start) + ' seconds')
+    if timing: print('Time to crop fixed volume ' + str(cropEnd - cropStart) + ' seconds')
+    if timing: print('Time to crop moving volume ' + str(crop2End - crop2Start) + ' seconds')
 
     # initialize the registration
     if timing: initTransformStart = time.time()
@@ -239,7 +242,7 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
     tx.SetCenter(fixedPoint)
     tx.SetTranslation(np.array(movingPoint) - np.array(fixedPoint))
     if timing: initTransformEnd = time.time()
-    if timing: print 'Time to initialize transformation was ' + str(initTransformEnd - initTransformStart) + ' seconds'
+    if timing: print('Time to initialize transformation was ' + str(initTransformEnd - initTransformStart) + ' seconds')
 
     # define the registration
     R = sitk.ImageRegistrationMethod()
@@ -280,7 +283,7 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
 
 
     if timing: regEnd = time.time()
-    if timing: print 'Time for local registration was ' + str(regEnd - regStart) + ' seconds'
+    if timing: print('Time for local registration was ' + str(regEnd - regStart) + ' seconds')
 
     # apply the local transform to the landmark
     #print transform
@@ -293,10 +296,10 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
     updatedPoint = [-updatedPoint[0], -updatedPoint[1], updatedPoint[2]]
     movingList.SetNthFiducialPosition(movingIndex, updatedPoint[0], updatedPoint[1], updatedPoint[2])
     if timing: resultEnd = time.time()
-    if timing: print 'Time for transforming landmark was ' + str(resultEnd - resultStart) + ' seconds'
+    if timing: print('Time for transforming landmark was ' + str(resultEnd - resultStart) + ' seconds')
 
     end = time.time()
-    print 'Refined landmark ' + state.currentLandmarkName + ' in ' + str(end - start) + ' seconds'
+    print('Refined landmark ' + state.currentLandmarkName + ' in ' + str(end - start) + ' seconds')
 
 
 

--- a/RegistrationLib/ThinPlatePlugin.py
+++ b/RegistrationLib/ThinPlatePlugin.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import vtk, qt, ctk, slicer
 from . import RegistrationPlugin
 
@@ -93,15 +95,15 @@ class ThinPlatePlugin(RegistrationPlugin):
     rasBounds = [0,]*6
     state.fixed.GetRASBounds(rasBounds)
     from math import floor, ceil
-    origin = map(int,map(floor,rasBounds[::2]))
-    maxes = map(int,map(ceil,rasBounds[1::2]))
+    origin = list(map(int,map(floor,rasBounds[::2])))
+    maxes = list(map(int,map(ceil,rasBounds[1::2])))
     boundSize = [m - o for m,o in zip(maxes,origin) ]
     spacing = state.fixed.GetSpacing()
-    samples = [ceil(b / s) for b,s in zip(boundSize,spacing)]
+    samples = [ceil(int(b / s)) for b,s in zip(boundSize,spacing)]
     extent = [0,]*6
     extent[::2] = [0,]*3
     extent[1::2] = samples
-    extent = map(int,extent)
+    extent = list(map(int,extent))
 
     toGrid = vtk.vtkTransformToGrid()
     toGrid.SetGridOrigin(origin)

--- a/RegistrationLib/__init__.py
+++ b/RegistrationLib/__init__.py
@@ -1,8 +1,8 @@
-from pqWidget import *
-from Visualization import *
-from Landmarks import *
-from RegistrationState import *
-from RegistrationPlugin import *
+from .pqWidget import *
+from .Visualization import *
+from .Landmarks import *
+from .RegistrationState import *
+from .RegistrationPlugin import *
 
 for plugin in [
   'Affine',
@@ -12,6 +12,6 @@ for plugin in [
   ]:
   try:
     __import__('RegistrationLib.%sPlugin' % plugin)
-  except ImportError, details:
+  except ImportError as details:
     import logging
     logging.warning("Registration: Failed to import '%s' plugin: %s" % (plugin, details))

--- a/RegistrationLib/pqWidget.py
+++ b/RegistrationLib/pqWidget.py
@@ -9,19 +9,19 @@ class pqWidget(object):
 
   def connect(self,signal,slot):
     """pseudo-connect - signal is arbitrary string and slot if callable"""
-    if not self.connections.has_key(signal):
+    if signal not in self.connections:
       self.connections[signal] = []
     self.connections[signal].append(slot)
 
   def disconnect(self,signal,slot):
     """pseudo-disconnect - remove the connection if it exists"""
-    if self.connections.has_key(signal):
+    if signal in self.connections:
       if slot in self.connections[signal]:
         self.connections[signal].remove(slot)
 
   def emit(self,signal,args):
     """pseudo-emit - calls any slots connected to signal"""
-    if self.connections.has_key(signal):
+    if signal in self.connections:
       for slot in self.connections[signal]:
         slot(*args)
 


### PR DESCRIPTION
This includes a cherry-picked commit authored by JC https://github.com/jcfr/LandmarkRegistration/commit/7fc2acc25daacf03895c063097e91289948fa013 which added Python 3 support and this commit is currently being used as part of Slicer's build process. I decided it might be worth while for this to be in the upstream master branch.

The second commit fixes an issue with old usages of vtkMRMLMarkups events.  I've replaced the two old references with the new events that best match the original event.  This should fix a long failing test with output such as http://slicer.cdash.org/testDetails.php?test=9823080&build=1742913.

@pieper After this is merged I can issue a PR to the Slicer repo to update the git hash and update the repo that is used to be this upstream version again.